### PR TITLE
Fix voices

### DIFF
--- a/public/scripts/bubble.js
+++ b/public/scripts/bubble.js
@@ -9,6 +9,9 @@ function Bubble(x, y, d, p) {
     this.diam = d;
     this.degree = p;
 
+    // Dtermines the distance from mouse location.
+    this.distX = 0;
+    this.distY = 0;
     this.isPressed = false;
 
     // Determines the coloring starting point.

--- a/public/scripts/effects.js
+++ b/public/scripts/effects.js
@@ -1,8 +1,7 @@
 const effects = {
     0: new Tone.Chorus(),
-    1: new Tone.Tremolo(),
     2: new Tone.PingPongDelay(),
-    3: new Tone.Chebyshev(50),
+    3: new Tone.Chebyshev(20),
     4: new Tone.Distortion(),
     5: new Tone.Reverb(),
     6: new Tone.JCReverb(),
@@ -16,7 +15,13 @@ effects.on = false;
  * random effects before going to master output.
  */
 function runEffect () {
-    if (effects.on) {
+    // Do not trigger a new effect is a note is already pressed,
+    // or if a previous effect has been initialized.
+    let notePressed = bubbles.some((note) => {
+        return note.isPressed;
+    })
+
+    if (effects.on || notePressed) {
         return;
     }
 

--- a/public/scripts/play.js
+++ b/public/scripts/play.js
@@ -36,7 +36,6 @@ function triggerAttack(idx) {
     context.resume();
 
     if (effects.clean) {
-        console.log("cleaning.");
         // Clean effect from current node
         polySynth.disconnect();
         polySynth.toMaster();
@@ -46,7 +45,7 @@ function triggerAttack(idx) {
     polySynth.triggerAttack(getNote(idx));
 }
 
-function triggerRelease(idx) {
+function triggerRelease() {
     polySynth.triggerRelease(notes);
 
     // Allow only fixed number of notes with effect

--- a/public/scripts/sketch.js
+++ b/public/scripts/sketch.js
@@ -34,6 +34,8 @@ function setup() {
 function mousePressed() {
     for (var i = 0; i < bubbles.length; i++) {
         bubbles[i].pressed();
+        bubbles[i].distX = mouseX - bubbles[i].x;
+        bubbles[i].distY = mouseY - bubbles[i].y;
     }
 }
 
@@ -46,8 +48,8 @@ function mouseReleased() {
 function mouseMoved() {
     for (var i = 0; i < bubbles.length; i++) {
         if (bubbles[i].isPressed) {
-            bubbles[i].x = mouseX;
-            bubbles[i].y = mouseY;
+            bubbles[i].x = mouseX - bubbles[i].distX ;
+            bubbles[i].y = mouseY - bubbles[i].distY;
         }
     }
 }


### PR DESCRIPTION
Added/fixed:
- Don't trigger effect if note is pressed, or if a previous effect is already "on"
- When dragging bubbles, use the distance from mouseX and mouseY avoid bubbles "jumping".